### PR TITLE
refactor: prioritize current site setting for org value

### DIFF
--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -91,25 +91,35 @@ class Microsite(models.Model):
         return microsites[0] if microsites else None
 
     @classmethod
-    def get_value_for_org(cls, org, val_name):
+    def get_value_for_org(cls, org, val_name, current_microsite):
         """
-        Filter the value by the org in the values field.
+        Filter the value by the org in the values field. Value from current
+        microsite is prioritized if org is present in multiple microsites
+        including the current one. Else the first valid value from an org is
+        returned.
 
         Args:
             org: String.
             key: String.
+            current_microsite: String
         Returns:
             The value for the given key and org.
         """
         results = cls.objects.filter(organizations__name=org)
+        first_result = None
 
         for result in results:
             value = result.values.get(val_name)
+            if value is None:
+                continue
 
-            if value:
+            if result.key == current_microsite:
                 return value
 
-        return None
+            if first_result is None:
+                first_result = value
+
+        return first_result
 
 
 class TenantConfigManager(models.Manager):
@@ -203,25 +213,35 @@ class TenantConfig(models.Model):
     objects = TenantConfigManager()
 
     @classmethod
-    def get_value_for_org(cls, org, val_name):
+    def get_value_for_org(cls, org, val_name, current_tenant):
         """
-        Filter the value by the org in the lms_config field.
+        Filter the value by the org in the lms_config field. Value from current
+        tenant is prioritized if org is present in multiple tenants including
+        the current one. Else the first valid value from an org is returned.
+
 
         Args:
             org: String.
-            key: String.
+            val_name: String.
+            current_tenant: String
         Returns:
             The value for the given key and org.
         """
         results = cls.objects.filter(organizations__name=org)
+        first_result = None
 
         for result in results:
             value = result.lms_configs.get(val_name)
+            if value is None:
+                continue
 
-            if value:
+            if result.external_key == current_tenant:
                 return value
 
-        return None
+            if first_result is None:
+                first_result = value
+
+        return first_result
 
 
 class Route(models.Model):

--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -150,18 +150,26 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
         TenantConfig or Microsite model.
         """
         cache_key = "org-value-{}-{}".format(org, val_name)
+
+        # Make use of tenant-external-key to generate unique cache_key per
+        # tenant. This will help to fetch the current tenant value if the org
+        # is configured in multiple tenants/microsites including the current
+        # one.
+        tenat_key = getattr(settings, "EDNX_TENANT_KEY", None)
+        if tenat_key is not None:
+            cache_key = "{}-{}".format(cache_key, tenat_key)
         cached_value = cache.get(cache_key)
 
         if cached_value:
             return cached_value
 
-        result = TenantConfig.get_value_for_org(org, val_name)
+        result = TenantConfig.get_value_for_org(org, val_name, tenat_key)
 
         if result:
             cls.set_key_to_cache(cache_key, result)
             return result
 
-        result = Microsite.get_value_for_org(org, val_name)
+        result = Microsite.get_value_for_org(org, val_name, tenat_key)
         result = result if result else default
         cls.set_key_to_cache(cache_key, result)
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

If multiple tenant configs are enabled for a given org, fetching value
from site config for the organization should return current site config
value if the org is included in the org_filter.

`Private-ref`: [BB-7927](https://tasks.opencraft.com/browse/BB-7927)

## Testing instructions

**Setup**
* Setup master devstack and start lms & cms using `make {lms,cms}-up`
* Clone this repo in <devstack_base_dir>/src/
* Checkout default branch in eox, i.e. `open-release/palm.master`.
* Open lms shell using `make lms-shell`.
* Run `pip install -e /edx/src/eox-tenant` in lms shell.
* Repeat above 2 steps to install eox in cms.
* Run `make {lms,cms}-migrate` to create eox tables.
* Goto eox tenant configs via: http://localhost:18000/admin/eox_tenant/tenantconfig/
* Add an entry with below details:
	* External key: `localhost:18000`
	* Lms configs:
    ```json
        {
            "EDNX_USE_SIGNAL": true,
            "LMS_BASE": "localhost:18000",
            "LMS_ROOT_URL": "http://locahost:18000",
            "SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT": "http://localhost:18000",
            "course_org_filter": [
                "edX"
            ]
        }
    ```
	* studio configs:
    ```json
        {
            "EDNX_USE_SIGNAL": true,
            "LMS_BASE": "localhost:18000",
            "LMS_ROOT_URL": "http://locahost:18000",
            "SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT": "http://localhost:18000",
            "course_org_filter": [
                "edX"
            ]
        }
    ```
* Add another entry with below details:
	* External key: `lacolhost.com:18000`
	* Lms configs:
    ```json
        {
            "EDNX_USE_SIGNAL": true,
            "LMS_BASE": "lacolhost.com:18000",
            "LMS_ROOT_URL": "http://lacolhost.com:18000",
            "course_org_filter": [
                "edX"
            ]
        }
    ```
	* studio configs:
    ```json
        {
            "EDNX_USE_SIGNAL": true,
            "LMS_BASE": "lacolhost.com:18000",
            "LMS_ROOT_URL": "http://lacolhost.com:18000",
            "SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT": "http://lacolhost.com:18000",
            "course_org_filter": [
                "edX"
            ]
        }
    ```
* Goto http://localhost:18000/admin/oauth2_provider/application/ and find application with name `studio-sso` and update its redirect urls to this value: `http://localhost:18010/complete/edx-oauth2/ http://localhost:18000/ http://lacolhost.com:18010/complete/edx-oauth2/ http://lacolhost.com:18000/ http://lacolhost.com http://edx.devstack.lms:18000/`
* Add localhost & lacolhost.com with its respective tenant config to routes: http://localhost:18000/admin/eox_tenant/route/
* Add `USE_EOX_TENANT = True` setting to `lms/envs/private.py` and `cms/envs/private.py` files

**Test**
* Login to studio via both urls, i.e.,  http://localhost:18010/ and http://lacolhost.com:18010/
* In the dashboard click or hover on `View Live` button, both the sites should take you to lacohost.com lms. The [first value from any site](https://github.com/open-craft/eox-tenant/blob/fe95928ad1f70931ee0fda6601332c39d11dd7f1/eox_tenant/models.py#L206-L224) having this org is returned which is lacolhost.com in this case.
* Now checkout this PR/branch and restart lms and cms using `make {lms,cms}-restart`.
* Login to studio again using both urls, when hovering on `View Live` button in localhost:18010, it should show its lms url, i.e. http://localhost:18000/courses/... and the button in lacolhost.com:18010 should show http://lacolhost.com:18000/courses/...



## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->